### PR TITLE
feat(web): add checkboxes to control plot bubbles and confidence lines

### DIFF
--- a/web/src/components/Regions/RegionPlotDots.tsx
+++ b/web/src/components/Regions/RegionPlotDots.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { useTheme } from 'styled-components'
 import type { Props as DotProps } from 'recharts/types/shape/Dot'
+import { useRecoilValue } from 'recoil'
+import { shouldShowBubblesOnRegionsPlotAtom, shouldShowConfidenceBarsOnRegionsPlotAtom } from 'src/state/settings.state'
 
 const AREA_FACTOR = 0.6
 const CIRCLE_LINEWIDTH = 2
@@ -16,6 +18,9 @@ export interface CustomizedDotProps extends DotProps {
 
 /** Line plot dot component which displays a bubble in proportion to frequency */
 export function CustomizedDot(props: CustomizedDotProps) {
+  const shouldShowBubbles = useRecoilValue(shouldShowBubblesOnRegionsPlotAtom)
+  const shouldShowConfidenceBars = useRecoilValue(shouldShowConfidenceBarsOnRegionsPlotAtom)
+
   const theme = useTheme()
   const y0 = theme.plot.margin.top
 
@@ -28,7 +33,7 @@ export function CustomizedDot(props: CustomizedDotProps) {
     height,
   } = props
 
-  if (!name || typeof height != 'number' || !cy || totals[name] === 0) {
+  if (!shouldShowBubbles || !name || typeof height != 'number' || !cy || totals[name] === 0) {
     return null
   }
 

--- a/web/src/components/Regions/RegionsPlotSettings.tsx
+++ b/web/src/components/Regions/RegionsPlotSettings.tsx
@@ -1,12 +1,46 @@
 import React, { useMemo } from 'react'
+import { Form } from 'reactstrap'
 import { CheckboxWithText } from 'src/components/Common/Checkbox'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { useRecoilToggle } from 'src/hooks/useToggle'
-import { shouldShowRangesOnRegionsPlotAtom } from 'src/state/settings.state'
+import {
+  shouldShowBubblesOnRegionsPlotAtom,
+  shouldShowConfidenceBarsOnRegionsPlotAtom,
+  shouldShowRangesOnRegionsPlotAtom,
+} from 'src/state/settings.state'
 
 export function RegionsPlotSettings() {
   const { t } = useTranslationSafe()
   const { state: shouldShowRanges, setState: setShouldShowRanges } = useRecoilToggle(shouldShowRangesOnRegionsPlotAtom)
-  const text = useMemo(() => t('Show confidence intervals'), [t])
-  return <CheckboxWithText title={text} label={text} checked={shouldShowRanges} setChecked={setShouldShowRanges} />
+  const { state: shouldShowConfidenceBars, setState: setShouldShowConfidenceBars } = useRecoilToggle(
+    shouldShowConfidenceBarsOnRegionsPlotAtom,
+  )
+  const { state: shouldShowBubbles, setState: setShouldShowBubbles } = useRecoilToggle(
+    shouldShowBubblesOnRegionsPlotAtom,
+  )
+  const textBubbles = useMemo(() => t('Show bubbles'), [t])
+  const textRanges = useMemo(() => t('Show confidence intervals'), [t])
+  const textBars = useMemo(() => t('Show confidence bars on hover'), [t])
+  return (
+    <Form>
+      <CheckboxWithText
+        title={textBubbles}
+        label={textBubbles}
+        checked={shouldShowBubbles}
+        setChecked={setShouldShowBubbles}
+      />
+      <CheckboxWithText
+        title={textRanges}
+        label={textRanges}
+        checked={shouldShowRanges}
+        setChecked={setShouldShowRanges}
+      />
+      <CheckboxWithText
+        title={textBars}
+        label={textBars}
+        checked={shouldShowConfidenceBars}
+        setChecked={setShouldShowConfidenceBars}
+      />
+    </Form>
+  )
 }

--- a/web/src/state/settings.state.ts
+++ b/web/src/state/settings.state.ts
@@ -13,6 +13,18 @@ export const shouldShowRangesOnRegionsPlotAtom = atom({
   effects: [persistAtom],
 })
 
+export const shouldShowConfidenceBarsOnRegionsPlotAtom = atom({
+  key: 'shouldShowConfidenceBarsOnRegionsPlotAtom',
+  default: false,
+  effects: [persistAtom],
+})
+
+export const shouldShowBubblesOnRegionsPlotAtom = atom({
+  key: 'shouldShowBubblesOnRegionsPlotAtom',
+  default: false,
+  effects: [persistAtom],
+})
+
 export const isSidebarSettingsCollapsedAtom = atom({
   key: 'isSidebarSettingsCollapsedAtom',
   default: false,


### PR DESCRIPTION
Followup of: https://github.com/neherlab/flu_frequencies/pull/11

/!\ WORK IN PROGRESS

As I suggested in the PR above, here I add recoil atoms to keep state (and remember it in the Local Storage), as well as checkbox elements, which would control display of bubbles and lines.

I hooked up the `shouldShowBubbles` state to completely disable the rendering of `CustomizedDot`. The rest is not connected yet. 

This is merely a suggestion. We may or may not take this path. The exact logic may change according to projects' needs. We may keep checkboxes or use other UI elemets as appropriate. The 3 checkboxes give 9 combinations of possible plot experiences.. Not all of them may make sense. We can try to limit number of checkboxes, or to use for example 2-way switch toggles (or 3-way, or N-way) or a dropdown menu instead.
