### PR TITLE
fixes #9 (tooltip improvements)

### DIFF
--- a/web/src/components/Regions/RegionsPlot.tsx
+++ b/web/src/components/Regions/RegionsPlot.tsx
@@ -128,7 +128,7 @@ function RegionsPlotImpl<T>({ width, height, data, minDate, maxDate, pathogen, c
         // @ts-ignore
         content={RegionsPlotTooltip}
         metadata={metadata}
-        isAnimationActive={true}
+        isAnimationActive
         allowEscapeViewBox={allowEscapeViewBox}
         offset={50}
         wrapperStyle={tooltipStyle}

--- a/web/src/components/Regions/RegionsPlot.tsx
+++ b/web/src/components/Regions/RegionsPlot.tsx
@@ -21,7 +21,7 @@ import { CustomizedDot, CustomizedActiveDot } from 'src/components/Common/Custom
 import { DateSlider } from 'src/components/Common/DateSlider'
 import { localeAtom } from 'src/state/locale.state'
 
-const allowEscapeViewBox = { x: false, y: true }
+const allowEscapeViewBox = { x: false, y: false }
 const tooltipStyle = { zIndex: 1000, outline: 'none' }
 
 interface LinePlotProps<T> {
@@ -128,7 +128,7 @@ function RegionsPlotImpl<T>({ width, height, data, minDate, maxDate, pathogen, c
         // @ts-ignore
         content={RegionsPlotTooltip}
         metadata={metadata}
-        isAnimationActive={false}
+        isAnimationActive={true}
         allowEscapeViewBox={allowEscapeViewBox}
         offset={50}
         wrapperStyle={tooltipStyle}

--- a/web/src/components/Regions/RegionsPlotTooltip.tsx
+++ b/web/src/components/Regions/RegionsPlotTooltip.tsx
@@ -57,7 +57,6 @@ export function RegionsPlotTooltip({ payload, metadata }: RegionsPlotTooltipProp
       const range = get(payload.ranges, variant)
       const value = get(payload.avgs, variant)
       const count = get(payload.counts, variant)
-      //const total = get(payload.totals, variant)
 
       return (
         <RegionsPlotTooltipRow
@@ -67,7 +66,6 @@ export function RegionsPlotTooltip({ payload, metadata }: RegionsPlotTooltipProp
           value={value}
           range={range}
           count={count}
-          //total={total}
         />
       )
     })

--- a/web/src/components/Regions/RegionsPlotTooltip.tsx
+++ b/web/src/components/Regions/RegionsPlotTooltip.tsx
@@ -49,6 +49,7 @@ export function RegionsPlotTooltip({ payload, metadata }: RegionsPlotTooltipProp
     }
 
     const date = formatDateWeekly(payload[0]?.payload?.timestamp)
+    const total = String(Object.values(payload[0]?.payload?.totals)[0])
 
     const data = reverse(sortBy(uniqBy(payload, 'name'), 'value'))
 
@@ -70,17 +71,19 @@ export function RegionsPlotTooltip({ payload, metadata }: RegionsPlotTooltipProp
       )
     })
 
-    return { date, rows }
+    return { date, total, rows }
   }, [metadata.pathogenName, payload])
 
   if (!result) {
     return result
   }
-  const { date, rows } = result
+  const { date, total, rows } = result
 
   return (
     <Tooltip>
-      <TooltipTitle>{date}</TooltipTitle>
+      <TooltipTitle>
+        {date} (Total: {total})
+      </TooltipTitle>
 
       <TooltipTable>
         <thead>

--- a/web/src/components/Regions/RegionsPlotTooltip.tsx
+++ b/web/src/components/Regions/RegionsPlotTooltip.tsx
@@ -16,7 +16,7 @@ const Tooltip = styled.div`
   display: flex;
   flex-direction: column;
   padding: 5px 10px;
-  background-color: #ffffff99;
+  background-color: ${(props) => props.theme.plot.tooltip.background};
   box-shadow: ${(props) => props.theme.shadows.blurredMedium};
   border-radius: 3px;
   outline: none;

--- a/web/src/components/Regions/RegionsPlotTooltip.tsx
+++ b/web/src/components/Regions/RegionsPlotTooltip.tsx
@@ -16,29 +16,23 @@ const Tooltip = styled.div`
   display: flex;
   flex-direction: column;
   padding: 5px 10px;
-  background-color: ${(props) => props.theme.plot.tooltip.background};
+  background-color: #ffffff99;
   box-shadow: ${(props) => props.theme.shadows.blurredMedium};
   border-radius: 3px;
   outline: none;
 `
 
 const TooltipTitle = styled.h3`
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 600;
   margin: 5px auto;
 `
 
 const TooltipTable = styled.table`
   padding: 30px 35px;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   border: none;
   min-width: 250px;
-
-  background-color: ${(props) => props.theme.plot.tooltip.table.backgroundEven};
-
-  & > tbody > tr:nth-child(odd) {
-    background-color: ${(props) => props.theme.plot.tooltip.table.backgroundOdd};
-  }
 `
 
 export interface RegionsPlotTooltipProps extends DefaultTooltipContentProps<number, string> {
@@ -63,7 +57,7 @@ export function RegionsPlotTooltip({ payload, metadata }: RegionsPlotTooltipProp
       const range = get(payload.ranges, variant)
       const value = get(payload.avgs, variant)
       const count = get(payload.counts, variant)
-      const total = get(payload.totals, variant)
+      //const total = get(payload.totals, variant)
 
       return (
         <RegionsPlotTooltipRow
@@ -73,7 +67,7 @@ export function RegionsPlotTooltip({ payload, metadata }: RegionsPlotTooltipProp
           value={value}
           range={range}
           count={count}
-          total={total}
+          //total={total}
         />
       )
     })
@@ -94,10 +88,9 @@ export function RegionsPlotTooltip({ payload, metadata }: RegionsPlotTooltipProp
         <thead>
           <tr className="w-100">
             <th className="px-2 text-left">{t('Variant')}</th>
-            <th className="px-2 text-right">{t('Frequency')}</th>
+            <th className="px-2 text-right">{t('Freq.')}</th>
             <th className="px-2 text-right">{t('Interval')}</th>
             <th className="px-2 text-right">{t('Count')}</th>
-            <th className="px-2 text-right">{t('Total')}</th>
           </tr>
         </thead>
         <tbody>{rows}</tbody>
@@ -112,10 +105,9 @@ interface RegionsPlotTooltipRowProps {
   value: number | undefined
   range: [number, number] | undefined
   count: number | undefined
-  total: number | undefined
 }
 
-function RegionsPlotTooltipRow({ pathogenName, variant, value, range, count, total }: RegionsPlotTooltipRowProps) {
+function RegionsPlotTooltipRow({ pathogenName, variant, value, range, count }: RegionsPlotTooltipRowProps) {
   const locale = useRecoilValue(localeAtom)
   const { color } = useVariantStyle(pathogenName, variant)
 
@@ -137,7 +129,6 @@ function RegionsPlotTooltipRow({ pathogenName, variant, value, range, count, tot
   }, [locale, range])
 
   const countDisplay = useMemo(() => maybe(formatInteger(locale), count), [count, locale])
-  const totalDisplay = useMemo(() => maybe(formatInteger(locale), total), [total, locale])
 
   return (
     <tr key={variant}>
@@ -148,7 +139,6 @@ function RegionsPlotTooltipRow({ pathogenName, variant, value, range, count, tot
       <td className="px-2 text-right">{valueDisplay}</td>
       <td className="px-2 text-right">{rangeDisplay}</td>
       <td className="px-2 text-right">{countDisplay}</td>
-      <td className="px-2 text-right">{totalDisplay}</td>
     </tr>
   )
 }

--- a/web/src/components/Variants/VariantsPlot.tsx
+++ b/web/src/components/Variants/VariantsPlot.tsx
@@ -129,7 +129,7 @@ function LinePlot<T>({ width, height, data, minDate, maxDate, pathogen, variantN
         // @ts-ignore
         content={VariantsPlotTooltip}
         metadata={metadata}
-        isAnimationActive={true}
+        isAnimationActive
         allowEscapeViewBox={allowEscapeViewBox}
         offset={50}
         wrapperStyle={tooltipStyle}

--- a/web/src/components/Variants/VariantsPlot.tsx
+++ b/web/src/components/Variants/VariantsPlot.tsx
@@ -21,7 +21,7 @@ import { CustomizedDot, CustomizedActiveDot } from 'src/components/Common/Custom
 import { DateSlider } from 'src/components/Common/DateSlider'
 import { localeAtom } from 'src/state/locale.state'
 
-const allowEscapeViewBox = { x: false, y: true }
+const allowEscapeViewBox = { x: false, y: false }
 const tooltipStyle = { zIndex: 1000, outline: 'none' }
 
 interface LinePlotProps<T> {
@@ -129,7 +129,7 @@ function LinePlot<T>({ width, height, data, minDate, maxDate, pathogen, variantN
         // @ts-ignore
         content={VariantsPlotTooltip}
         metadata={metadata}
-        isAnimationActive={false}
+        isAnimationActive={true}
         allowEscapeViewBox={allowEscapeViewBox}
         offset={50}
         wrapperStyle={tooltipStyle}

--- a/web/src/components/Variants/VariantsPlotTooltip.tsx
+++ b/web/src/components/Variants/VariantsPlotTooltip.tsx
@@ -16,29 +16,23 @@ const Tooltip = styled.div`
   display: flex;
   flex-direction: column;
   padding: 5px 10px;
-  background-color: ${(props) => props.theme.plot.tooltip.background};
+  background-color: #ffffff99;
   box-shadow: ${(props) => props.theme.shadows.blurredMedium};
   border-radius: 3px;
   outline: none;
 `
 
 const TooltipTitle = styled.h3`
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 600;
   margin: 5px auto;
 `
 
 const TooltipTable = styled.table`
   padding: 30px 35px;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   border: none;
   min-width: 250px;
-
-  background-color: ${(props) => props.theme.plot.tooltip.table.backgroundEven};
-
-  & > tbody > tr:nth-child(odd) {
-    background-color: ${(props) => props.theme.plot.tooltip.table.backgroundOdd};
-  }
 `
 
 export interface VariantsPlotTooltipProps extends DefaultTooltipContentProps<number, string> {
@@ -94,7 +88,7 @@ export function VariantsPlotTooltip({ payload, metadata }: VariantsPlotTooltipPr
         <thead>
           <tr className="w-100">
             <th className="px-2 text-left">{t('Country')}</th>
-            <th className="px-2 text-right">{t('Frequency')}</th>
+            <th className="px-2 text-right">{t('Freq.')}</th>
             <th className="px-2 text-right">{t('Interval')}</th>
             <th className="px-2 text-right">{t('Count')}</th>
             <th className="px-2 text-right">{t('Total')}</th>

--- a/web/src/components/Variants/VariantsPlotTooltip.tsx
+++ b/web/src/components/Variants/VariantsPlotTooltip.tsx
@@ -16,7 +16,7 @@ const Tooltip = styled.div`
   display: flex;
   flex-direction: column;
   padding: 5px 10px;
-  background-color: #ffffff99;
+  background-color: ${(props) => props.theme.plot.tooltip.background};
   box-shadow: ${(props) => props.theme.shadows.blurredMedium};
   border-radius: 3px;
   outline: none;

--- a/web/src/helpers/format.ts
+++ b/web/src/helpers/format.ts
@@ -13,7 +13,6 @@ export const formatProportion = (locale: string) => (value: number) => {
 }
 
 export const formatRange = (locale: string) => (begin: number, end: number) => {
-  //return `[${formatProportion(locale)(begin)}; ${formatProportion(locale)(end)}]`
   return `${formatProportion(locale)(begin)}-${formatProportion(locale)(end)}`
 }
 

--- a/web/src/helpers/format.ts
+++ b/web/src/helpers/format.ts
@@ -13,7 +13,8 @@ export const formatProportion = (locale: string) => (value: number) => {
 }
 
 export const formatRange = (locale: string) => (begin: number, end: number) => {
-  return `[${formatProportion(locale)(begin)}; ${formatProportion(locale)(end)}]`
+  //return `[${formatProportion(locale)(begin)}; ${formatProportion(locale)(end)}]`
+  return `${formatProportion(locale)(begin)}-${formatProportion(locale)(end)}`
 }
 
 export const formatInteger = (locale: string) => (value: number) => {

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -137,7 +137,7 @@ export const plot = {
   tickStyle: { fontSize: 12 },
   tickWidthMin: 100,
   tooltip: {
-    background: white,
+    background: '#ffffff99',
     table: {
       backgroundEven: gray100,
       backgroundOdd: gray200,


### PR DESCRIPTION
- removed Total column from Region tooltip
- changed format for confidence intervals in tooltip
- abbreviated "Frequency"
- reduced font size
- switched to semi-transparent background
- activated tooltip animation for less jerky movements (easier to read)