### PR TITLE
Specify string dtype for "variant" field

### DIFF
--- a/scripts/pop_weighted_aggregates.py
+++ b/scripts/pop_weighted_aggregates.py
@@ -224,7 +224,12 @@ def main(
     """
 
     # Filter out unknown regions
-    fit_results = pl.read_csv(_fit_results).filter(c("region") != "?")
+    fit_results = pl.read_csv(
+        _fit_results,
+        dtypes={
+            "variant": pl.Utf8,
+        }
+    ).filter(c("region") != "?")
     country_to_population = read_tsv(_country_to_population).select(
         country=c("iso3"), population=c("population")
     )


### PR DESCRIPTION
Fixes an issue where the "variant" field can be inferred to have a dtype of integer when a clade (or "variant") name in flu is an integer (e.g., clade "1" in H1N1pdm nomenclature), causing a parsing error when a non-integer clade name is encountered later in the same file.